### PR TITLE
Add missing open dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,17 @@
             "dependencies": {
                 "@nightwatch/html-reporter-template": "^0.2.1",
                 "jimp": "^0.16.0",
-                "lodash": "^4.17.4"
+                "lodash": "^4.17.4",
+                "open": "^8.4.2"
             },
             "devDependencies": {
                 "eslint": "^8.27.0",
                 "jest": "^28.1.0",
                 "nightwatch": "^3.0.1",
                 "rimraf": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 16"
             }
         },
         "../../../Downloads/package 2": {
@@ -2968,7 +2972,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
             "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4296,7 +4299,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
             "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -4553,7 +4555,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
             "dependencies": {
                 "is-docker": "^2.0.0"
             },
@@ -6139,6 +6140,23 @@
             "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
             "dev": true
         },
+        "node_modules/nightwatch/node_modules/open": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+            "dev": true,
+            "dependencies": {
+                "define-lazy-prop": "^2.0.0",
+                "is-docker": "^2.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/nightwatch/node_modules/semver": {
             "version": "7.3.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -6294,10 +6312,9 @@
             }
         },
         "node_modules/open": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-            "dev": true,
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
             "dependencies": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",
@@ -10227,8 +10244,7 @@
         "define-lazy-prop": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-            "dev": true
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
         },
         "define-properties": {
             "version": "1.2.0",
@@ -11213,8 +11229,7 @@
         "is-docker": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -11381,7 +11396,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
             "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dev": true,
             "requires": {
                 "is-docker": "^2.0.0"
             }
@@ -12649,6 +12663,17 @@
                     "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
                     "dev": true
                 },
+                "open": {
+                    "version": "8.4.0",
+                    "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+                    "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+                    "dev": true,
+                    "requires": {
+                        "define-lazy-prop": "^2.0.0",
+                        "is-docker": "^2.1.1",
+                        "is-wsl": "^2.2.0"
+                    }
+                },
                 "semver": {
                     "version": "7.3.5",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -12774,10 +12799,9 @@
             }
         },
         "open": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-            "dev": true,
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
             "requires": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "dependencies": {
         "@nightwatch/html-reporter-template": "^0.2.1",
         "jimp": "^0.16.0",
-        "lodash": "^4.17.4"
+        "lodash": "^4.17.4",
+        "open": "^8.4.2"
     },
     "devDependencies": {
         "eslint": "^8.27.0",


### PR DESCRIPTION
open is accessed directly, but not declared, which means it cannot run in Yarn > 2

```
   Error
    Unable to load plugin: @nightwatch/vrt: [MODULE_NOT_FOUND] @nightwatch/vrt tried to access open, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

It can be temporarily fixed per-project by adding the following to `.yarnrc.yml`:
```
packageExtensions:
  "@nightwatch/vrt@*":
     dependencies:
       open: "^8"
```